### PR TITLE
Added timeout parameter for unzip

### DIFF
--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -41,8 +41,8 @@
 #  defaults to 'windows/unzip.ps1.erb'.
 #
 # [*timeout*]
-# Execution timeout in seconds for the unzip command, 0 disables timeout
-# defaults to 300 seconds
+# Execution timeout in seconds for the unzip command; 0 disables timeout,
+# defaults to 300 seconds (5 minutes).
 #
 define windows::unzip(
   $destination,

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -40,6 +40,10 @@
 #  Advanced paramter for generating PowerShell that extracts the ZIP file,
 #  defaults to 'windows/unzip.ps1.erb'.
 #
+# [*timeout*]
+# Execution timeout in seconds for the unzip command, 0 disables timeout
+# defaults to 300 seconds
+#
 define windows::unzip(
   $destination,
   $creates          = undef,
@@ -49,6 +53,7 @@ define windows::unzip(
   $provider         = 'powershell',
   $options          = '20',
   $command_template = 'windows/unzip.ps1.erb',
+  $timeout          = 300,
 ) {
   validate_absolute_path($destination)
 
@@ -62,5 +67,6 @@ define windows::unzip(
     refreshonly => $refreshonly,
     unless      => $unless,
     provider    => $provider,
+    timeout     => $timeout,
   }
 }


### PR DESCRIPTION
I'm using this module to extract some very large zip files. Some take longer than the puppet exec default of 300 seconds. So I added a timeout parameter that gets passed on to the exec. It defaults to the same default as exec, 300 seconds.