### PR TITLE
Fixed disabling screen saver

### DIFF
--- a/templates/screen_saver_check.ps1.erb
+++ b/templates/screen_saver_check.ps1.erb
@@ -10,7 +10,9 @@ foreach($property in "ScreenSaveActive","SCRNSAVE.EXE","ScreenSaverIsSecure","Sc
     if ( ! ($regkey.Property -contains $property)) { exit 1; }
 }
 if ( (Get-ItemProperty -Path $regpath -Name "ScreenSaveActive").ScreenSaveActive -ne <%= @active_value %>) { exit 1; }
+<% if @active_value == 1 -%>
 if ( (Get-ItemProperty -Path $regpath -Name "SCRNSAVE.EXE")."SCRNSAVE.EXE" -ne "<%= @exe %>") { exit 1; }
+<% end -%>
 if ( (Get-ItemProperty -Path $regpath -Name "ScreenSaverIsSecure").ScreenSaverIsSecure -ne <%= @secure_value %>) { exit 1; }
 if ( (Get-ItemProperty -Path $regpath -Name "ScreenSaveTimeout").ScreenSaveTimeout -ne <%= @timeout_seconds %>) { exit 1; }
 exit 0;

--- a/templates/screen_saver_set.ps1.erb
+++ b/templates/screen_saver_set.ps1.erb
@@ -8,6 +8,8 @@ $regpath = "Registry::HKEY_USERS\${sid}\Control Panel\Desktop";
 Set-ItemProperty -Path $regpath -Name "ScreenSaveActive" -Value <%= @active_value %> -Force;
 <% if @active_value == 1 -%>
 Set-ItemProperty -Path $regpath -Name "SCRNSAVE.EXE" -Value "<%= @exe %>" -Force;
+<% else -%>
+Remove-ItemProperty -Path $regpath -Name "SCRNSAVE.EXE";
 <% end -%>
 Set-ItemProperty -Path $regpath -Name "ScreenSaverIsSecure" -Value <%= @secure_value %> -Force;
 Set-ItemProperty -Path $regpath -Name "ScreenSaveTimeOut" -Value <%= @timeout_seconds %> -Force;

--- a/templates/screen_saver_set.ps1.erb
+++ b/templates/screen_saver_set.ps1.erb
@@ -6,6 +6,8 @@ $user = New-Object System.Security.Principal.NTAccount("<%= @user %>");
 $sid = ($user.Translate([System.Security.Principal.SecurityIdentifier])).Value;
 $regpath = "Registry::HKEY_USERS\${sid}\Control Panel\Desktop";
 Set-ItemProperty -Path $regpath -Name "ScreenSaveActive" -Value <%= @active_value %> -Force;
+<% if @active_value == 1 -%>
 Set-ItemProperty -Path $regpath -Name "SCRNSAVE.EXE" -Value "<%= @exe %>" -Force;
+<% end -%>
 Set-ItemProperty -Path $regpath -Name "ScreenSaverIsSecure" -Value <%= @secure_value %> -Force;
 Set-ItemProperty -Path $regpath -Name "ScreenSaveTimeOut" -Value <%= @timeout_seconds %> -Force;


### PR DESCRIPTION
At least on Windows 2008R2, setting `ScreenSaveActive` isn't enough to disable the screen saver. You have to remove the `SCRNSAVE.EXE` key.