### PR TITLE
Allow newer powershell versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4 (10/15/2016)
+
+IMPROVEMENTS:
+* Allow newer versions of puppetlabs/powershell.
+
 ## 1.0.3 (06/07/2016)
 
 IMPROVEMENTS:

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description": "Collection of useful Puppet manifests for Windows-based platforms.",
   "dependencies": [
     {"name": "counsyl/sys", "version_requirement": ">= 0.9.18 <2.0.0"},
-    {"name": "puppetlabs/powershell", "version_requirement": ">= 1.0.4 <2.0.0"},
+    {"name": "puppetlabs/powershell", "version_requirement": ">= 1.0.4 <3.0.0"},
     {"name": "puppetlabs/registry", "version_requirement": ">= 1.1.0 <2.0.0"}
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "counsyl-windows",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Counsyl, Inc.",
   "summary": "Collection of useful Puppet manifests for Windows-based platforms.",
   "license": "Apache-2.0",


### PR DESCRIPTION
@jbronn @lucaswiman Support the use of newer versions of `puppetlabs/powershell` with the `counsyl/windows` module.

The only backwards incompatible change appears to be dropping support  for Windows Server 2003.
