### PR TITLE
Fixing issues when puppet runs as service

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ windows::unzip { 'C:\compressed.zip':
 }
 ```
 
+If you don't have .NET 4.5 installed you can fallback to COM based method but it can fail if puppet runs as service. 
+
+```puppet
+windows::unzip { 'C:\compressed.zip':
+  destination => 'C:\dest',
+  creates     => 'C:\dest\uncompressed.txt',
+  provider    => 'com'
+}
+```
+
 This assumes that the file `uncompressed.txt` exists in `C:\compressed.zip`
 
 License

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you don't have .NET 4.5 installed you can fallback to COM based method but it
 windows::unzip { 'C:\compressed.zip':
   destination => 'C:\dest',
   creates     => 'C:\dest\uncompressed.txt',
-  provider    => 'com'
+  fallback    => true,
 }
 ```
 

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -61,13 +61,13 @@ define windows::unzip(
     fail("Must set one of creates, refreshonly, or unless parameters.\n")
   }
 
-  unless( $provider == 'dotnet'  or $provider == 'com'){
+  unless ($provider == 'dotnet' or $provider == 'com'){
     fail("Wrong provider: `${provider}', choices are: dotnet or com!\n")
   }
 
-  if ($provider ==  'dotnet'){
+  if ($provider == 'dotnet'){
     $command_template = 'windows/unzip_dotnet.ps1.erb'
-  }else{
+  } else{
     $command_template = 'windows/unzip.ps1.erb'
   }
 

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -50,10 +50,11 @@ define windows::unzip(
   $refreshonly      = false,
   $unless           = undef,
   $zipfile          = $name,
-  $provider         = 'dotnet',
+  $provider         = 'powershell',
   $options          = '20',
   $timeout          = 300,
   $logoutput        = on_failure,
+  $fallback         = false,
 ) {
   validate_absolute_path($destination)
 
@@ -61,23 +62,18 @@ define windows::unzip(
     fail("Must set one of creates, refreshonly, or unless parameters.\n")
   }
 
-  unless ($provider == 'dotnet' or $provider == 'com'){
-    fail("Wrong provider: `${provider}', choices are: dotnet or com!\n")
-  }
-
-  if ($provider == 'dotnet'){
-    $command_template = 'windows/unzip_dotnet.ps1.erb'
-  } else{
+  if ($fallback){
     $command_template = 'windows/unzip.ps1.erb'
+  } else{
+    $command_template = 'windows/unzip_dotnet.ps1.erb'
   }
-
 
   exec { "unzip-${name}":
     command     => template($command_template),
     creates     => $creates,
     refreshonly => $refreshonly,
     unless      => $unless,
-    provider    => powershell,
+    provider    => $provider,
     timeout     => $timeout,
     logoutput   => $logoutput,
   }

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -50,10 +50,10 @@ define windows::unzip(
   $refreshonly      = false,
   $unless           = undef,
   $zipfile          = $name,
-  $provider         = 'powershell',
+  $provider         = 'dotnet',
   $options          = '20',
-  $command_template = 'windows/unzip.ps1.erb',
   $timeout          = 300,
+  $logoutput        = on_failure,
 ) {
   validate_absolute_path($destination)
 
@@ -61,12 +61,24 @@ define windows::unzip(
     fail("Must set one of creates, refreshonly, or unless parameters.\n")
   }
 
+  unless( $provider == 'dotnet'  or $provider == 'com'){
+    fail("Wrong provider: `${provider}', choices are: dotnet or com!\n")
+  }
+
+  if ($provider ==  'dotnet'){
+    $command_template = 'windows/unzip_dotnet.ps1.erb'
+  }else{
+    $command_template = 'windows/unzip.ps1.erb'
+  }
+
+
   exec { "unzip-${name}":
     command     => template($command_template),
     creates     => $creates,
     refreshonly => $refreshonly,
     unless      => $unless,
-    provider    => $provider,
+    provider    => powershell,
     timeout     => $timeout,
+    logoutput   => $logoutput,
   }
 }

--- a/templates/unzip.ps1.erb
+++ b/templates/unzip.ps1.erb
@@ -1,3 +1,22 @@
-$shell = New-Object -COMObject Shell.Application;
-$zipfile = $shell.NameSpace("<%= @zipfile %>");
-foreach($item in $zipfile.Items()){ $shell.NameSpace("<%= @destination %>").CopyHere($item, <%= @options %>) };
+$zipFile="<%= @zipfile %>"
+$dst="<%= @destination %>"
+
+if ( ! (Test-Path $zipfile) ) {
+    write-error "ZIP file does not exists: `$zipFile'"
+    exit 1
+}
+
+if ( ! (Test-Path $dst) ) {
+    write-error "Missing destination folder: `$dst'"
+    exit 1
+}
+
+try {
+    $shell = New-Object -COMObject Shell.Application;
+    $zipfile = $shell.NameSpace("<%= @zipfile %>");
+    foreach($item in $zipfile.Items()){ $shell.NameSpace("<%= @destination %>").CopyHere($item, <%= @options %>) };
+}
+catch {
+    write-error $_
+    exit 1
+}

--- a/templates/unzip_dotnet.ps1.erb
+++ b/templates/unzip_dotnet.ps1.erb
@@ -1,0 +1,21 @@
+$zipFile="<%= @zipfile %>"
+$dst="<%= @destination %>"
+
+if ( ! (Test-Path $zipfile) ) {
+    write-error "ZIP file does not exists: ``$zipFile'"
+    exit 1
+}
+
+if ( ! (Test-Path $dst) ) {
+    write-error "Missing destination folder: ``$dst'"
+    exit 1
+}
+
+try {
+    Add-Type -A System.IO.Compression.FileSystem
+    [IO.Compression.ZipFile]::ExtractToDirectory($zipFile, $dst)
+}
+catch {
+    write-error $_
+    exit 1
+}


### PR DESCRIPTION
If puppet runs as service the following exceptions are raised:
The server threw an exception. (Exception from HRESULT: 0x80010105
(RPC_E_SERVERFAULT))
You cannot call a method on a null-valued expression.

Surrunded the method with try-catch and added better error handling
logic

Added a "virtual" provider and .NET based method, which is available
from windows .NET 4.5 (Windows 8) and made it default.

But left the original as a fallback.